### PR TITLE
Bugfix: `device` argument

### DIFF
--- a/polos/models/estimators/polos_estimator.py
+++ b/polos/models/estimators/polos_estimator.py
@@ -93,7 +93,7 @@ class PolosEstimator(Estimator):
             torch.nn.Sigmoid()
         ])
 
-        self.clip, self.clip_preprocess = clip.load("ViT-B/32", device="cuda")
+        self.clip, self.clip_preprocess = clip.load("ViT-B/32", device=self.device)
         self.parallel_feature_extraction = parallel_feature_extraction
 
 


### PR DESCRIPTION
The `device` argument of the `load` function was fixed-set to "cuda", causing an exception on non-GPU setups. I corrected this to `self.device`, which solved the problem.